### PR TITLE
feat: move settings and change naming

### DIFF
--- a/public/utils/menuTemplate.js
+++ b/public/utils/menuTemplate.js
@@ -19,9 +19,15 @@ const menuTemplate = [
         {
           label: app.getName(),
           submenu: [
-            { role: 'about' },
+            { type: 'about' },
             { type: 'separator' },
-            { role: 'services' },
+            {
+              label: 'Settings',
+              accelerator: 'CmdOrCtrl+,',
+              click() {
+                createSettingsWindow();
+              },
+            },
             { type: 'separator' },
             { role: 'hide' },
             { role: 'hideothers' },
@@ -36,27 +42,21 @@ const menuTemplate = [
     label: 'File',
     submenu: [
       {
-        label: 'Run Inputfile',
-        accelerator: 'CmdOrCtrl+S',
+        label: 'Run file...',
+        accelerator: 'CmdOrCtrl+O',
         click() {
           getFileAndLaunch();
         },
       },
-      {
-        label: 'IMC-ROV Mockup',
-        accelerator: 'CmdOrCtrl+M',
-        click: async () => {
-          createMockupWindow();
-          ipcCommunicationTCPServer();
-        },
-      },
-      {
-        label: 'Settings',
-        accelerator: 'CmdOrCtrl+I',
-        click() {
-          createSettingsWindow();
-        },
-      },
+      process.platform === 'darwin'
+        ? []
+        : {
+            label: 'Settings',
+            accelerator: 'CmdOrCtrl+,',
+            click() {
+              createSettingsWindow();
+            },
+          },
     ],
   },
   {
@@ -83,6 +83,15 @@ const menuTemplate = [
   {
     label: 'View',
     submenu: [
+      {
+        label: 'Show IMC-ROV Mockup',
+        accelerator: 'CmdOrCtrl+M',
+        click: async () => {
+          createMockupWindow();
+          ipcCommunicationTCPServer();
+        },
+      },
+      { type: 'separator' },
       { role: 'reload' },
       { role: 'forcereload' },
       { role: 'toggledevtools' },
@@ -100,14 +109,14 @@ const menuTemplate = [
     label: 'Controls',
     submenu: [
       {
-        label: 'Gamepad Controls',
+        label: 'Show Gamepad Controls',
         accelerator: 'CmdOrCtrl+G',
         click: async () => {
           createXboxMappingWindow();
         },
       },
       {
-        label: 'Keyboard Controls',
+        label: 'Show Keyboard Controls',
         accelerator: 'CmdOrCtrl+K',
         click: async () => {
           createKeyboardMappingWindow();

--- a/public/utils/menuTemplate.js
+++ b/public/utils/menuTemplate.js
@@ -19,7 +19,7 @@ const menuTemplate = [
         {
           label: app.getName(),
           submenu: [
-            { type: 'about' },
+            { role: 'about' },
             { type: 'separator' },
             {
               label: 'Settings',
@@ -48,15 +48,17 @@ const menuTemplate = [
           getFileAndLaunch();
         },
       },
-      process.platform === 'darwin'
+      ...(process.platform === 'darwin'
         ? []
-        : {
-            label: 'Settings',
-            accelerator: 'CmdOrCtrl+,',
-            click() {
-              createSettingsWindow();
+        : [
+            {
+              label: 'Settings',
+              accelerator: 'CmdOrCtrl+,',
+              click() {
+                createSettingsWindow();
+              },
             },
-          },
+          ]),
     ],
   },
   {

--- a/public/utils/menuTemplate.js
+++ b/public/utils/menuTemplate.js
@@ -33,10 +33,10 @@ const menuTemplate = [
       ]
     : []),
   {
-    label: 'Simulator',
+    label: 'File',
     submenu: [
       {
-        label: 'Open Simulator',
+        label: 'Run Inputfile',
         accelerator: 'CmdOrCtrl+S',
         click() {
           getFileAndLaunch();
@@ -48,6 +48,13 @@ const menuTemplate = [
         click: async () => {
           createMockupWindow();
           ipcCommunicationTCPServer();
+        },
+      },
+      {
+        label: 'Settings',
+        accelerator: 'CmdOrCtrl+I',
+        click() {
+          createSettingsWindow();
         },
       },
     ],
@@ -62,25 +69,14 @@ const menuTemplate = [
           getConnectedClient();
         },
       },
-      {
+      // This button really doesn't do anything?
+      /* {
         label: 'Start ROV Serial Port',
         accelerator: 'CmdOrCtrl+C',
         click() {
           getFileAndLaunch(global.settings.serialFile);
         },
-      },
-    ],
-  },
-  {
-    label: 'Settings',
-    submenu: [
-      {
-        label: 'Program settings',
-        accelerator: 'CmdOrCtrl+I',
-        click() {
-          createSettingsWindow();
-        },
-      },
+      }, */
     ],
   },
   // { role: 'viewMenu' }


### PR DESCRIPTION
Changes the dropdown menus according to feedback from testing at Frøya.

- `Simulator` is now `File`. When on the boat you still run the same file, but it is not a simulator out there.
- `Settings` is moved under `File` because that is normal convention
- `Start ROV Serial Port` commented out, because this doesn't do anything. Please give comment on this part!!